### PR TITLE
Swap $HOME/go to $GOPATH

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,7 @@
 
 BOOTSTRAP_VERSION=1
 BOOTSTRAP_REPO=github.com/fyne-io/bootstrap
-BOOTSTRAP_DIR=$HOME/go/src/github.com/fyne-io/bootstrap
+BOOTSTRAP_DIR=$GOPATH/src/github.com/fyne-io/bootstrap
 
 CONFIG_DIR=$HOME/.config/fyne/bootstrap/
 LOG_FILE=$CONFIG_DIR/install.log


### PR DESCRIPTION
Script will error our when a user with a non standard GOPATH tries to run it.
This solves that issue by using the GOPATH exported from the users shell profile.